### PR TITLE
Remove `ini_hex` and `ini_HEX` on 1.6+

### DIFF
--- a/src/printf.jl
+++ b/src/printf.jl
@@ -10,4 +10,11 @@ if VERSION < v"1.1"
 else
   fix_dec(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = fix_dec(out, Float32(d),          flags, width, precision, c, digits)
   ini_dec(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_dec(out, Float32(d), ndigits, flags, width, precision, c, digits)
+  
+  if VERSION < v"1.6"
+    ini_hex(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d), ndigits, flags, width, precision, c, digits)
+    ini_HEX(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_HEX(out, Float32(d), ndigits, flags, width, precision, c, digits)
+    ini_hex(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d),          flags, width, precision, c, digits)
+    ini_HEX(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = ini_HEX(out, Float32(d),          flags, width, precision, c, digits)
+  end
 end

--- a/src/printf.jl
+++ b/src/printf.jl
@@ -1,4 +1,4 @@
-import Printf: ini_dec, fix_dec, ini_hex, ini_HEX
+import Printf: ini_dec, fix_dec
 
 if VERSION < v"1.1"
   fix_dec(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char) = fix_dec(out, Float32(d),          flags, width, precision, c)
@@ -10,8 +10,4 @@ if VERSION < v"1.1"
 else
   fix_dec(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = fix_dec(out, Float32(d),          flags, width, precision, c, digits)
   ini_dec(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_dec(out, Float32(d), ndigits, flags, width, precision, c, digits)
-  ini_hex(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d), ndigits, flags, width, precision, c, digits)
-  ini_HEX(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_HEX(out, Float32(d), ndigits, flags, width, precision, c, digits)
-  ini_hex(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d),          flags, width, precision, c, digits)
-  ini_HEX(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = ini_HEX(out, Float32(d),          flags, width, precision, c, digits)
 end

--- a/src/printf.jl
+++ b/src/printf.jl
@@ -1,6 +1,8 @@
 import Printf: ini_dec, fix_dec
 
 if VERSION < v"1.1"
+  import Printf: ini_hex, ini_HEX
+  
   fix_dec(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char) = fix_dec(out, Float32(d),          flags, width, precision, c)
   ini_dec(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char) = ini_dec(out, Float32(d), ndigits, flags, width, precision, c)
   ini_hex(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char) = ini_hex(out, Float32(d), ndigits, flags, width, precision, c)

--- a/src/printf.jl
+++ b/src/printf.jl
@@ -12,6 +12,8 @@ else
   ini_dec(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_dec(out, Float32(d), ndigits, flags, width, precision, c, digits)
   
   if VERSION < v"1.6"
+    import Printf: ini_hex, ini_HEX
+    
     ini_hex(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d), ndigits, flags, width, precision, c, digits)
     ini_HEX(out, d::BFloat16, ndigits::Int, flags::String, width::Int, precision::Int, c::Char, digits) = ini_HEX(out, Float32(d), ndigits, flags, width, precision, c, digits)
     ini_hex(out, d::BFloat16,               flags::String, width::Int, precision::Int, c::Char, digits) = ini_hex(out, Float32(d),          flags, width, precision, c, digits)


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/32859, https://github.com/JuliaMath/DoubleFloats.jl/pull/125. This is causing warnings downstream in CUDA.jl.