### PR TITLE
add trunc so round works

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -87,6 +87,7 @@ end
 
 # Truncation to integer types
 Base.unsafe_trunc(T::Type{<:Integer}, x::BFloat16) = unsafe_trunc(T, Float32(x))
+Base.trunc(::Type{T}, x::BFloat16) where {T<:Integer} = trunc(T, Float32(x))
 
 # Basic arithmetic
 for f in (:+, :-, :*, :/, :^)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,3 +107,7 @@ end
   y = randexp(BFloat16, 10)
   @test x !== y
 end
+
+@testset "round" begin
+  @test round(Int, BFloat16(3.4)) == 3
+end


### PR DESCRIPTION
rounding from BFloat16 to Integer does not currently work.  adding a trunc method fixes it.

what i don't understand is why there is a [trunc method](https://github.com/JuliaMath/BFloat16s.jl/blob/master/src/bfloat16.jl#L54-L55) to convert Float32 to BFloat16.  all other trunc methods convert to Integer.  but this is unrelated to this PR.  just saw that in the code.