### PR TITLE
Adapt to upstream changes wrt. native support for BFloat16

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -15,6 +15,8 @@ import Base: isfinite, isnan, precision, iszero, eps,
     asinh, acosh, atanh, acsch, asech, acoth,
     bitstring, isinteger
 
+import Printf
+
 # LLVM 11 added support for BFloat16 in the IR; Julia 1.11 added support for generating
 # code that uses the `bfloat` IR type, together with the necessary runtime functions.
 # However, not all LLVM targets support `bfloat`. If the target can store/load BFloat16s
@@ -332,6 +334,7 @@ function Base.show(io::IO, x::BFloat16)
         hastypeinfo || print(io, ")")
     end
 end
+Printf.tofloat(x::BFloat16) = Float32(x)
 
 # Random
 import Random: rand, randn, randexp, AbstractRNG, Sampler

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -16,12 +16,13 @@ import Base: isfinite, isnan, precision, iszero, eps,
     bitstring, isinteger
 
 # Julia 1.11 provides codegen support for BFloat16
-if isdefined(Core, :BFloat16)
+const codegen_support = if isdefined(Core, :BFloat16) &&
+                           Sys.ARCH in [:x86_64, :i686]
     using Core: BFloat16
-    const codegen_support = true
+    true
 else
     primitive type BFloat16 <: AbstractFloat 16 end
-    const codegen_support = false
+    false
 end
 
 Base.reinterpret(::Type{Unsigned}, x::BFloat16) = reinterpret(UInt16, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test, BFloat16s, Printf, Random
 
+@info "Testing BFloat16s" BFloat16s.llvm_storage BFloat16s.llvm_arithmetic
+
 @testset "comparisons" begin
     @test BFloat16(1)   <  BFloat16(2)
     @test BFloat16(1f0) <  BFloat16(2f0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,14 @@ end
     @test Int64(BFloat16(10)) == Int64(10)
 end
 
+@testset "abi" begin
+  f() = BFloat16(1)
+  @test f() == BFloat16(1)
+
+  g(x) = x+BFloat16(1)
+  @test g(BFloat16(2)) == BFloat16(3)
+end
+
 @testset "functions" begin
     @test abs(BFloat16(-10)) == BFloat16(10)
     @test BFloat16(2) ^ BFloat16(4) == BFloat16(16)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ end
                        ("%.2a",    "0x1.3cp+0"),
                        ("%.2A",    "0X1.3CP+0")),
         num in (BFloat16(1.234),)
-        @test @eval(@sprintf($fmt, $num) == $val)
+        @eval @test @sprintf($fmt, $num) == $val
     end
     @test (@sprintf "%f" BFloat16(Inf)) == "Inf"
     @test (@sprintf "%f" BFloat16(NaN)) == "NaN"
@@ -75,7 +75,7 @@ end
                        ("%-+10.5g",    "+123.5    "),
                        ("%010.5g", "00000123.5")),
         num in (BFloat16(123.5),)
-        @test @eval(@sprintf($fmt, $num) == $val)
+        @eval @test @sprintf($fmt, $num) == $val
     end
     @test( @sprintf( "%10.5g", BFloat16(-123.5) ) == "    -123.5")
     @test( @sprintf( "%010.5g", BFloat16(-123.5) ) == "-0000123.5")


### PR DESCRIPTION
This PR adapts BFloat16s.jl to https://github.com/JuliaLang/julia/pull/51470, where I'm adding native support for BFloat16s to Julia (using the `bfloat` type in LLVM). I decided to keep as much functionality as possible in this package, so Base only defines `Core.BFloat16` and the necessary codegen support.

The main benefit of this change is that we now emit drastically simpler IR, and rely on LLVM to lower it to something that the hardware supports. For example:

```julia
julia> test(x::T) where T = T(2) * x + one(T)

julia> test(BFloat16(1))
BFloat16(3.0)
```

Before this PR:

```
julia> @code_llvm debuginfo=:none test(BFloat16(1))
define i16 @julia_test_556(i16 zeroext %0) #0 {
top:
  %1 = zext i16 %0 to i32
  %2 = shl nuw i32 %1, 16
  %bitcast_coercion = bitcast i32 %2 to float
  %3 = fmul float %bitcast_coercion, 2.000000e+00
  %4 = fcmp ord float %3, 0.000000e+00
  br i1 %4, label %L38, label %L75

L38:                                              ; preds = %top
  %bitcast_coercion4 = bitcast float %3 to i32
  %5 = lshr i32 %bitcast_coercion4, 16
  %.op5 = and i32 %5, 1
  %6 = add i32 %bitcast_coercion4, 32767
  %7 = add i32 %6, %.op5
  %8 = and i32 %7, -65536
  %phi.cast = bitcast i32 %8 to float
  %phi.bo = fadd float %phi.cast, 1.000000e+00
  %9 = fcmp ord float %phi.bo, 0.000000e+00
  br i1 %9, label %L54, label %L75

L54:                                              ; preds = %L38
  %bitcast_coercion3 = bitcast float %phi.bo to i32
  %10 = lshr i32 %bitcast_coercion3, 16
  %11 = and i32 %10, 1
  %narrow = add nuw nsw i32 %11, 32767
  %12 = zext i32 %narrow to i64
  %13 = zext i32 %bitcast_coercion3 to i64
  %14 = add nuw nsw i64 %12, %13
  %15 = lshr i64 %14, 16
  %16 = trunc i64 %15 to i16
  br label %L75

L75:                                              ; preds = %L54, %L38, %top
  %value_phi2 = phi i16 [ %16, %L54 ], [ 32704, %L38 ], [ 32704, %top ]
  ret i16 %value_phi2
}

julia> @code_native debuginfo=:none test(BFloat16(1))
julia_test_560:                         # @julia_test_560
# %bb.0:                                # %top
	shl	edi, 16
	mov	ax, 32704
	vmovd	xmm0, edi
	vaddss	xmm0, xmm0, xmm0
	vucomiss	xmm0, xmm0
	jp	.LBB0_3
# %bb.1:                                # %L38
	push	rbp
	vmovd	ecx, xmm0
	movabs	rdx, offset .LCPI0_0
	mov	rbp, rsp
	bt	ecx, 16
	adc	ecx, 32767
	and	ecx, -65536
	vmovd	xmm0, ecx
	vaddss	xmm0, xmm0, dword ptr [rdx]
	vucomiss	xmm0, xmm0
	pop	rbp
	jp	.LBB0_3
# %bb.2:                                # %L54
	vmovd	eax, xmm0
	bt	eax, 16
	adc	eax, 32767
	shr	eax, 16
.LBB0_3:                                # %L75
                                        # kill: def $ax killed $ax killed $eax
	ret
```

Using this PR, on https://github.com/JuliaLang/julia/pull/51470:

```
julia> @code_llvm debuginfo=:none test(BFloat16(1))
; Function Signature: test(Core.BFloat16)
define bfloat @julia_test_2911(bfloat %"x::BFloat16") #0 {
top:
  %0 = fpext bfloat %"x::BFloat16" to float
  %1 = fmul float %0, 2.000000e+00
  %2 = fptrunc float %1 to bfloat
  %3 = fpext bfloat %2 to float
  %4 = fadd float %3, 1.000000e+00
  %5 = fptrunc float %4 to bfloat
  ret bfloat %5
}

julia> @code_native debuginfo=:none test(BFloat16(1))
julia_test_3001:                        # @julia_test_3001
; Function Signature: test(Core.BFloat16)
# %bb.0:                                # %top
	#DEBUG_VALUE: test:x <- $xmm0
	push	rbp
	mov	rbp, rsp
	push	rbx
	sub	rsp, 8
	vmovd	eax, xmm0
	movabs	rbx, offset __truncsfbf2
	shl	eax, 16
	vmovd	xmm0, eax
	vaddss	xmm0, xmm0, xmm0
	call	rbx
	vmovd	eax, xmm0
	movabs	rcx, offset .LCPI0_0
	shl	eax, 16
	vmovd	xmm0, eax
	vaddss	xmm0, xmm0, dword ptr [rcx]
	call	rbx
	add	rsp, 8
	pop	rbx
	pop	rbp
	ret
```

So the LLVM IR is much simpler, while the native code is (as expected) similar in complexity.

Performance is hard to compare for such simple operations, but representing BFloat16s natively should make it possible for LLVM to optimize them, and also select better instructions when possible. For example, with a CPU supporting AVX512BF16 and LLVM 17, we compile:

```
define <16 x bfloat> @trunc(<16 x float>) {
    %2 = fptrunc <16 x float> %0 to <16 x bfloat>
    ret <16 x bfloat> %2
}
```

to:

```
trunc:                                  # @trunc
        vcvtneps2bf16   ymm0, zmm0
        ret
```

So this will make it possible to use BFloat16s.jl with our vectorization packages (by using `NTuple{16,Core.VecElement{BFloat}}`, which now lowers to `<16 x bfloat>`).

---

This PR also switches the `significand` implementation, as it contained undefined behavior (for `one(BFloat16)`, `isig` is `Int16(0)`). The new implementation is copied from Base.

Closes https://github.com/JuliaMath/BFloat16s.jl/pull/51