### PR TITLE
add maxintfloat(::Type{BFloat16})

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -145,6 +145,7 @@ typemin(::Type{BFloat16}) = -InfB16
 typemax(::Type{BFloat16}) = InfB16
 floatmax(::Type{BFloat16}) = reinterpret(BFloat16, 0x7f7f)
 floatmin(::Type{BFloat16}) = reinterpret(BFloat16, 0x0080)
+Base.maxintfloat(::Type{BFloat16}) = reinterpret(BFloat16,0x4380) # = BFloat16(256)
 
 # Truncation from Float32
 Base.uinttype(::Type{BFloat16}) = UInt16

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,5 +168,12 @@ end
   @test nextfloat(-floatmin(BFloat16),2^8) > 0
 end
 
+@testset "maxintfloat" begin
+  
+  a = maxintfloat(BFloat16)
+  @test a+1-1 == a-1    # the first +1 cannot be represented
+  @test a-1+1 == a      # but -1 can
+end
+
 include("structure.jl")
 include("mathfuncs.jl")


### PR DESCRIPTION
`maxintfloat(T)` is the largest integer `n` so that `n+1` is not representable anymore with a given format `T`. For BFloat16 this is $256 = 2^{n_m+1}$ with $n_m = 7$ the number of mantissa bits.

```julia
julia> BFloat16(256)
BFloat16(256.0)

julia> BFloat16(257)
BFloat16(256.0)

julia> BFloat16(258)
BFloat16(258.0)
```