### PR TITLE
Bump to v0.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BFloat16s"
 uuid = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 authors = ["Keno Fischer <keno@alumni.harvard.edu>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
@maleadt @DilumAluthge @JeffreySarnoff I was wondering whether we can tag the current master as v0.4.3, meaning a non-breaking change. I believe all commits merged since v0.4.2 haven't been breaking but please let me know if we should use v0.5 instead