### PR TITLE
BFloat16(::BigFloat) and BigFloat(::BFloat16)

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -220,6 +220,10 @@ else
     end
 end
 
+# BigFloat conversion
+BFloat16(x::BigFloat) = BFloat16(Float32(x))
+Base.BigFloat(x::BFloat16) = BigFloat(Float32(x))
+
 # Basic arithmetic
 if llvm_arithmetic
     +(x::T, y::T) where {T<:BFloat16} = Base.add_float(x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ end
     @test Float64(BFloat16(10)) == 10.0
     @test Int32(BFloat16(10)) == Int32(10)
     @test Int64(BFloat16(10)) == Int64(10)
+    @test BFloat16(BigFloat(1)) == BFloat16(1)
+    @test BigFloat(BFloat16(1)) == BigFloat(1)
 end
 
 @testset "abi" begin


### PR DESCRIPTION
We currently have
```julia
julia> BigFloat(BFloat16(1))
ERROR: MethodError: no method matching BigFloat(::BFloat16)
```
and
```julia
julia> convert(BFloat16,BigFloat(1))
ERROR: MethodError: no method matching BFloat16(::BigFloat)
```

This PR just defines those conversions via Float32, outside of the `llvm_arithmetic` blocks because I believe there's no LLVM functionality for BigFloat hence his needs to happen independently anyway.