### PR TITLE
`rand` via scaled random integers

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -363,8 +363,8 @@ from every BFloat16 in [1/2, 1) but only from every other
 in [1/4, 1/2), and every forth in [1/8, 1/4), etc. for a
 uniform distribution."""
 function rand(rng::AbstractRNG, ::Sampler{BFloat16})
-    # Float32(0x1.0p-8) is 2^-8 = eps(BFloat16)/2
-    return BFloat16(Float32(rand(rng, UInt8)) * Float32(0x1.0p-8))
+    # 0x1p-8 is 2^-8 = eps(BFloat16)/2
+    return rand(rng, UInt8) * BFloat16(0x1p-8)
 end
 
 randn(rng::AbstractRNG, ::Type{BFloat16}) = convert(BFloat16, randn(rng))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,10 +184,8 @@ end
   # zero should be the lowest BFloat16 sampled
   @test mi === zero(BFloat16)
 
-  # prevfloat(one(BFloat16)) cannot be sampled bc
-  # prevfloat(BFloat16(2)) - 1 is _two_ before one(BFloat16)
-  # (a statistical flaw of the [1,2)-1 sampling)
-  @test ma === prevfloat(one(BFloat16), 2)
+  # prevfloat(one(BFloat16)) should be maximum
+  @test ma === prevfloat(one(BFloat16), 1)
 end
 
 include("structure.jl")


### PR DESCRIPTION
fixes #79 

Question remains @oscardssmith: Why write (1)
```julia
BFloat16(Float32(rand(rng, UInt8)) * Float32(0x1.0p-8))
```

and not just (2)

```julia
rand(rng, UInt8) * BFloat16(0x1.0p-8)
```
? 
From a precision perspective they are the same (no rounding errors in `BFloat16` arithmetic because you exactly hit eps/2, eps, 3eps/2, n*eps/2 which are all perfectly representable) but in (1) the actual multiplication is hardcoded in `Float32`
which avoids the conversion from `BFloat16(0x1.0p-8)` to `Float32` if `BFloat16` is not natively supported, I believe? Meaning it's probably faster if `bfloat16` is not natively supported. Whereas with (2) we would have the advantage that LLVM's `bfloat` type would decide what to do depending on the hardware meaning it would be faster on devices with `bfloat16` support (as multiplication is then not done with `Float32`?)