### PR TITLE
CI: Test on more systems

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.10'
+          - 'min'
+          - 'lts'
           - '1'
           - 'pre'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.10'
           - '1'
           - 'pre'
         os:
@@ -24,6 +25,9 @@ jobs:
         include:
           - os: macos-latest
             arch: aarch64
+            version: '1'
+          - os: macos-13
+            arch: x64
             version: '1'
             
     steps:


### PR DESCRIPTION
Test on Julia 1.10 since it's the LTS version.
Continue to test on Julia 1.6 since that's still working.
Test on x86_64 macOS as well.
