### PR TITLE
Add read/write support for BFloat16 values

### DIFF
--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -424,3 +424,8 @@ for F in (:abs, :abs2, :sqrt, :cbrt,
      Base.$F(x::BFloat16) = BFloat16($F(Float32(x)))
   end
 end
+
+# i/o
+Base.write(io::IO, num::BFloat16) = write(io, UInt16(reinterpret(UInt32, Float32(num)) >> 16))
+Base.read(io::IO, ::Type{BFloat16})::BFloat16 = reinterpret(BFloat16, read(io, UInt16))
+Base.bswap(x::BFloat16) = Base.bswap_int(x)

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -434,7 +434,7 @@ for F in (:abs, :abs2, :sqrt, :cbrt,
 end
 
 # i/o
-Base.write(io::IO, num::BFloat16) = write(io, UInt16(reinterpret(UInt32, Float32(num)) >> 16))
+Base.write(io::IO, num::BFloat16) = write(io, reinterpret(UInt16, num))
 Base.read(io::IO, ::Type{BFloat16})::BFloat16 = reinterpret(BFloat16, read(io, UInt16))
 Base.bswap(x::BFloat16) = Base.bswap_int(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,5 +188,18 @@ end
   @test ma === prevfloat(one(BFloat16), 1)
 end
 
+@testset "i/o" begin
+    @test reinterpret(UInt16, BFloat16(1/3)) == 0x3eab
+    @test reinterpret(UInt16, bswap(BFloat16(1/3))) == 0xab3e
+
+    io = IOBuffer()
+
+    write(io, htol(BFloat16(3.14159)))
+    @test take!(io) == UInt8[0x49, 0x40]
+
+    write(io, hton(BFloat16(3.14159)))
+    @test take!(io) == UInt8[0x40, 0x49]
+end
+
 include("structure.jl")
 include("mathfuncs.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,9 @@ end
 
     write(io, hton(BFloat16(3.14159)))
     @test take!(io) == UInt8[0x40, 0x49]
+
+    @test htol(read(IOBuffer(UInt8[0x49, 0x40]), BFloat16)) == BFloat16(3.14159)
+    @test hton(read(IOBuffer(UInt8[0x40, 0x49]), BFloat16)) == BFloat16(3.14159)
 end
 
 include("structure.jl")


### PR DESCRIPTION
Includes bswap(), which is used internally by hton/ntoh/etc so you can handle either order.

Fixes #96