### PR TITLE
Print shortest decimal that survives round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ julia> a = BFloat16(2)
 BFloat16(2.0)
 
 julia> sqrt(a)
-BFloat16(1.4140625)
+BFloat16(1.414)
 ```
 
 However, in practice you may hit a `MethodError` indicating that this package does not implement
@@ -43,21 +43,21 @@ of `BFloat16` should be as smooth as the following example, solving a linear equ
 ```julia
 julia> A = randn(BFloat16,3,3)
 3×3 Matrix{BFloat16}:
-  1.46875   -1.20312   -1.0
-  0.257812  -0.671875  -0.929688
- -0.410156  -1.75      -0.0162354
+  1.47   -1.2   -1.0
+  0.258  -0.67  -0.93
+ -0.41   -1.75  -0.0162
 
 julia> b = randn(BFloat16,3)
 3-element Vector{BFloat16}:
- -0.26367188
- -0.14160156
-  0.77734375
+ -0.264
+ -0.142
+  0.777
 
 julia> A\b
 3-element Vector{BFloat16}:
- -0.24902344
- -0.38671875
-  0.36328125
+ -0.249
+ -0.387
+  0.363
 ```
 
 ## `LowPrecArray` for mixed-precision Float32/BFloat16 matrix multiplications

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -357,12 +357,13 @@ end
 # long output like `BFloat16(0.100097656)` for what is conceptually `0.1`).
 function _shortest_decimal_string(x::BFloat16)
     iszero(x) && return signbit(x) ? "-0.0" : "0.0"
-    f64 = Float64(Float32(x))
-    for ndig in 1:17
-        rounded = round(f64, sigdigits=ndig)
+    f32 = Float32(x)
+    for ndig in 1:9
+        s = Printf.@sprintf("%.*e", ndig - 1, f32)
+        rounded = parse(Float64, s)
         BFloat16(rounded) === x && return string(rounded)
     end
-    return string(f64)
+    return string(Float64(f32))
 end
 
 function Base.show(io::IO, x::BFloat16)

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -367,8 +367,9 @@ function _format_sci(f64::Float64, n::Int)
 end
 
 # 4 sig digits suffice for BFloat16 by ceil(8*log10(2))+1.
-# When the n-sig decimal isn't representable in Float64, Ryu's shortest form
-# blows up (e.g. "2.9999999999999998e-40"); detect via length and reformat.
+# `round(f64, sigdigits=n)` can land ~1 ULP off the Float64 that parsing the
+# n-digit decimal would yield, making Ryu emit 17 digits to disambiguate
+# (e.g. "2.9999999999999998e-40"); detect via length and reformat.
 function _shortest_decimal_string(x::BFloat16)
     x === zero(BFloat16) && return "0.0"
     x === -zero(BFloat16) && return "-0.0"

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -351,19 +351,37 @@ end
 
 # Showing
 
-# Shortest decimal that round-trips through BFloat16's 8-bit precision.
-# Mirrors Julia's `show(::Float16)` behavior tuned to the source type rather
-# than leaking Float32's 24-bit reconstruction (which produced misleadingly
-# long output like `BFloat16(0.100097656)` for what is conceptually `0.1`).
-function _shortest_decimal_string(x::BFloat16)
-    iszero(x) && return signbit(x) ? "-0.0" : "0.0"
-    f32 = Float32(x)
-    for ndig in 1:9
-        s = Printf.@sprintf("%.*e", ndig - 1, f32)
-        rounded = parse(Float64, s)
-        BFloat16(rounded) === x && return string(rounded)
+function _format_sci(f64::Float64, n::Int)
+    ax = abs(f64)
+    e = floor(Int, log10(ax))
+    k = n - 1 - e
+    scaled = k >= 0 ? ax * exp10(k) : ax / exp10(-k)
+    m = round(Int, scaled)
+    if m >= 10^n
+        m ÷= 10
+        e += 1
     end
-    return string(Float64(f32))
+    digits = lpad(string(m), n, '0')
+    mantissa = n == 1 ? digits * ".0" : digits[1:1] * "." * digits[2:n]
+    return (signbit(f64) ? "-" : "") * mantissa * "e" * string(e)
+end
+
+# 4 sig digits suffice for BFloat16 by ceil(8*log10(2))+1.
+# When the n-sig decimal isn't representable in Float64, Ryu's shortest form
+# blows up (e.g. "2.9999999999999998e-40"); detect via length and reformat.
+function _shortest_decimal_string(x::BFloat16)
+    x === zero(BFloat16) && return "0.0"
+    x === -zero(BFloat16) && return "-0.0"
+    isfinite(x) || return string(Float64(x))
+    f64 = Float64(x)
+    for ndig in 1:4
+        rounded = round(f64, sigdigits=ndig)
+        BFloat16(rounded) === x || continue
+        s = string(rounded)
+        length(s) <= ndig + 8 && return s
+        return _format_sci(f64, ndig)
+    end
+    return string(f64)
 end
 
 function Base.show(io::IO, x::BFloat16)

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -350,6 +350,21 @@ for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UIn
 end
 
 # Showing
+
+# Shortest decimal that round-trips through BFloat16's 8-bit precision.
+# Mirrors Julia's `show(::Float16)` behavior tuned to the source type rather
+# than leaking Float32's 24-bit reconstruction (which produced misleadingly
+# long output like `BFloat16(0.100097656)` for what is conceptually `0.1`).
+function _shortest_decimal_string(x::BFloat16)
+    iszero(x) && return signbit(x) ? "-0.0" : "0.0"
+    f64 = Float64(Float32(x))
+    for ndig in 1:17
+        rounded = round(f64, sigdigits=ndig)
+        BFloat16(rounded) === x && return string(rounded)
+    end
+    return string(f64)
+end
+
 function Base.show(io::IO, x::BFloat16)
     hastypeinfo = BFloat16 === get(io, :typeinfo, Any)
     if isinf(x)
@@ -358,7 +373,7 @@ function Base.show(io::IO, x::BFloat16)
         print(io, "NaNB16")
     else
         hastypeinfo || print(io, "BFloat16(")
-        show(IOContext(io, :typeinfo=>Float32), Float32(x))
+        print(io, _shortest_decimal_string(x))
         hastypeinfo || print(io, ")")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,6 +159,11 @@ end
         @test BFloat16(parse(Float64, s)) === x
     end
 
+    # Every finite BFloat16 bit pattern round-trips through its shown decimal.
+    @test all(u -> (x = reinterpret(BFloat16, u); !isfinite(x) ||
+                    BFloat16(parse(Float64, BFloat16s._shortest_decimal_string(x))) === x),
+              UInt16(0):UInt16(0xffff))
+
     # In array context, type prefix is suppressed.
     buf = IOBuffer()
     show(IOContext(buf, :typeinfo => BFloat16), BFloat16(0.1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,25 @@ end
     @test repr(BFloat16(-Inf)) == "-InfB16"
     @test repr(BFloat16(NaN)) == "NaNB16"
     @test repr(BFloat16(2)) == "BFloat16(2.0)"
+
+    # Precision-aware: shown digit count reflects BFloat16's 8-bit precision,
+    # not Float32's 24-bit reconstruction.
+    @test repr(BFloat16(0.1))   == "BFloat16(0.1)"   # was "BFloat16(0.100097656)"
+    @test repr(BFloat16(1.0))   == "BFloat16(1.0)"
+    @test repr(BFloat16(-0.0)) == "BFloat16(-0.0)"
+
+    # Round-trip invariant: parsing the shown decimal and reconstructing
+    # through BFloat16 lands on the same bit pattern.
+    for v in (0.1, 1.5, 3.14, 1e10, 1e-10, nextfloat(1.0, 1000))
+        x = BFloat16(v)
+        s = BFloat16s._shortest_decimal_string(x)
+        @test BFloat16(parse(Float64, s)) === x
+    end
+
+    # In array context, type prefix is suppressed.
+    buf = IOBuffer()
+    show(IOContext(buf, :typeinfo => BFloat16), BFloat16(0.1))
+    @test String(take!(buf)) == "0.1"
 end
 
 @testset "parse" for _parse in (parse, tryparse)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,26 +145,20 @@ end
     @test repr(BFloat16(NaN)) == "NaNB16"
     @test repr(BFloat16(2)) == "BFloat16(2.0)"
 
-    # Precision-aware: shown digit count reflects BFloat16's 8-bit precision,
-    # not Float32's 24-bit reconstruction.
-    @test repr(BFloat16(0.1))   == "BFloat16(0.1)"   # was "BFloat16(0.100097656)"
-    @test repr(BFloat16(1.0))   == "BFloat16(1.0)"
+    @test repr(BFloat16(0.1))  == "BFloat16(0.1)"
+    @test repr(BFloat16(1.0))  == "BFloat16(1.0)"
     @test repr(BFloat16(-0.0)) == "BFloat16(-0.0)"
 
-    # Round-trip invariant: parsing the shown decimal and reconstructing
-    # through BFloat16 lands on the same bit pattern.
     for v in (0.1, 1.5, 3.14, 1e10, 1e-10, nextfloat(1.0, 1000))
         x = BFloat16(v)
         s = BFloat16s._shortest_decimal_string(x)
         @test BFloat16(parse(Float64, s)) === x
     end
 
-    # Every finite BFloat16 bit pattern round-trips through its shown decimal.
     @test all(u -> (x = reinterpret(BFloat16, u); !isfinite(x) ||
                     BFloat16(parse(Float64, BFloat16s._shortest_decimal_string(x))) === x),
               UInt16(0):UInt16(0xffff))
 
-    # In array context, type prefix is suppressed.
     buf = IOBuffer()
     show(IOContext(buf, :typeinfo => BFloat16), BFloat16(0.1))
     @test String(take!(buf)) == "0.1"


### PR DESCRIPTION
Floating points in Julia Base find the shortest decimal string that still returns the same narrow value returns after a conversion round-trip. For example:

```julia-repl
julia> Float16(1) |> nextfloat
Float16(1.001)

julia> ans |> Float32
1.0009766f0

julia> ans |> Float16
Float16(1.001)

julia> Float32(1) |> nextfloat
1.0000001f0

julia> ans |> Float64
1.0000001192092896

julia> ans |> Float32
1.0000001f0
```

This PR applies the same principle to `BFloat16`:

```julia-repl
julia> BFloat16(1) |> nextfloat
BFloat16(1.01)

julia> ans |> Float32
1.0078125f0

julia> ans |> BFloat16
BFloat16(1.01)
```

BFloat16 has ~2-3 decimal digits of precision; the current output prints ~8, suggesting precision the format doesn't have.

Before:

```julia-repl
julia> rand(BFloat16, 8)
8-element Vector{BFloat16}:
 0.8515625
 0.12109375
 0.69140625
 0.71484375
 0.765625
 0.79296875
 0.09765625
 0.703125
```

After:

```julia-repl
julia> rand(BFloat16, 8)
8-element Vector{BFloat16}:
 0.85
 0.121
 0.69
 0.715
 0.766
 0.793
 0.0977
 0.703
```

This includes a test that exhaustively round-trips the 2^16 possible values.